### PR TITLE
Update smuggler.py's help

### DIFF
--- a/smuggler.py
+++ b/smuggler.py
@@ -670,7 +670,7 @@ parser.add_argument( "-o","--hosts",help="set host list (required or -u)" )
 parser.add_argument( "-s","--scheme",help="scheme to use, default: http,https" )
 parser.add_argument( "-t","--threads",help="threads, default 10" )
 parser.add_argument( "-u","--urls",help="set url list (required or -o)" )
-parser.add_argument( "-v","--verbose",help="display output, 0=nothing, 1=only vulnerable, 2=all requests, 3=requests+headers, 4=full debug, default: 1" )
+parser.add_argument( "-v","--verbose",help="display output, 0=nothing, 1=only vulnerable, 2=all requests, 3=requests+headers, 4=full debug, default: 2" )
 parser.parse_args()
 args = parser.parse_args()
 


### PR DESCRIPTION
Commit https://github.com/gwen001/pentest-tools/commit/3b1bf1e416b6a0fadaa3cf5ee11b16da2bc27dea changed the default value but didn't update the help output