### PR TITLE
Safely ignore exception when sock.shutdown() is called on a disconnected socket.

### DIFF
--- a/smuggler.py
+++ b/smuggler.py
@@ -12,6 +12,7 @@ import os
 import sys
 import ssl
 import time
+import errno
 import random
 import argparse
 import socket
@@ -517,7 +518,17 @@ class sockRequest:
             return False
         
         end = time.time()
-        sock.shutdown( socket.SHUT_RDWR )
+
+        try:
+            sock.shutdown( socket.SHUT_RDWR )
+        except Exception as e:
+            if type(e).__name__ == 'OSError' and e.errno == errno.ENOTCONN:
+                # Socket was already disconnected. Whatevs.
+                pass
+            else:
+                sys.stdout.write( "%s[-] error occurred: %s (%s)%s\n" % (fg('red'),e,self.url,attr(0)) )
+                return False
+
         sock.close()
 
         self.response = datas


### PR DESCRIPTION
When using the smuggler tool on some sites, I was getting an error that stopped the run. Perhaps there's a way to make sure that shutdown() isn't called when the socket has already been closed. But catching and ignoring this exception seems to be effective.

```
 $ python3 smuggler.py -v 2 -u http://example.com                                                                                                         13:41:42

                                         _                             
         ___ _ __ ___  _   _  __ _  __ _| | ___ _ __       _ __  _   _ 
        / __| '_ ` _ \| | | |/ _` |/ _` | |/ _ \ '__|     | '_ \| | | |
        \__ \ | | | | | |_| | (_| | (_| | |  __/ |     _  | |_) | |_| |
        |___/_| |_| |_|\__,_|\__, |\__, |_|\___|_|    (_) | .__/ \__, |
                             |___/ |___/                  |_|    |___/ 

                        by @gwendallecoguic


[+] 0 hosts found: None
[+] 1 urls found: http://example.com
[+] 1 path found: None
[+] options are -> threads:10, verbose:2
[+] 1 urls to test.
[+] testing...
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.7.6_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/threading.py", line 926, in _bootstrap_inner
    self.run()
  File "/usr/local/Cellar/python/3.7.6_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "smuggler.py", line 802, in doWork
    testURL( url )
  File "smuggler.py", line 614, in testURL
    r = doRequest( url, msg )
  File "smuggler.py", line 629, in doRequest
    r.send()
  File "smuggler.py", line 520, in send
    sock.shutdown( socket.SHUT_RDWR )
OSError: [Errno 57] Socket is not connected
```