### PR TITLE
cast port to int

### DIFF
--- a/smuggler.py
+++ b/smuggler.py
@@ -491,6 +491,7 @@ class sockRequest:
         # print( self.url )
         # print( port )
         # print( '>>>'+self.message+'<<<' )
+	port = int(port)
 
         sock = socket.socket( socket.AF_INET, socket.SOCK_STREAM )
 


### PR DESCRIPTION
fixes "send (connect) - error occurred: an integer is required (got type str)" when doing "http(s)://x.x.x.x:port"

i just quickly made this pull request from the github web editor to let you know. maybe there are other problems and stuff that come from this i dunno