### PR TITLE
Account for 'signatureOrSystem'

### DIFF
--- a/apk-analyzer.py
+++ b/apk-analyzer.py
@@ -115,7 +115,7 @@ def printPermissionsCreated( tab, plevel0='' ):
             if k in obj.attrib['name']:
                 extra = v
                 plevel = 'warning'
-        if not 'protectionLevel' in obj.attrib or obj.attrib['protectionLevel'] != 'signature':
+        if not 'protectionLevel' in obj.attrib or 'signature' not in obj.attrib['protectionLevel']:
             extra = 'no signature'
             plevel = 'warning'
         _print( obj.attrib['name'], extra, plevel0+plevel )


### PR DESCRIPTION
Fixes the return of a false-positive when the permission level is set to `signatureOrSystem`.