### PR TITLE
Adding GitLab Runner Registration Token

### DIFF
--- a/keyhacks.sh
+++ b/keyhacks.sh
@@ -27,6 +27,7 @@ function usage() {
     echo "  - github_ssh_key"
     echo "  - github_token"
     echo "  - gitlab_private_token"
+    echo "  - gitlab_runner_registration_token"
     echo "  - google_cm"
     echo "  - google_maps_key"
     echo "  - heroku_api_key"
@@ -256,6 +257,24 @@ case $1 in
             cmd="curl 'https://$2/api/v4/projects?private_token=$3'"
         else
             echo "Usage: $0 $1 <subdomain> <token>"
+        fi
+    ;;
+    'gitlab_runner_registration_token')
+        if [ $# -eq 2 ] ; then
+            cmd="docker run --rm gitlab/gitlab-runner register \
+              --non-interactive \
+              --executor \"docker\" \
+              --docker-image alpine:latest \
+              --url \"https://gitlab.com/\" \
+              --registration-token \"${2}\" \
+              --description \"keyhacks-test\" \
+              --maintenance-note \"Testing token with keyhacks\" \
+              --tag-list \"docker,aws\" \
+              --run-untagged=\"true\" \
+              --locked=\"false\" \
+              --access-level=\"not_protected\""
+        else
+            echo "Usage: $0 $1 <token>"
         fi
     ;;
     'google_cm')


### PR DESCRIPTION
Example output for good token:
```
$ ./keyhacks.sh gitlab_runner_registration_token GR1348941RLoRqn-LN-ZsZHUoa23A
docker run --rm gitlab/gitlab-runner register --non-interactive --executor "docker" --docker-image alpine:latest --url "https://gitlab.com/" --registration-token "GR1348941RLoRqn-LN-ZsZHUoa23A" --description "keyhacks-test" --maintenance-note "Testing token with keyhacks" --tag-list "docker,aws" --run-untagged="true" --locked="false" --access-level="not_protected"

Runtime platform                                    arch=amd64 os=linux pid=7 revision=32fc1585 version=15.2.1
Running in system-mode.                            
                                                   
Registering runner... succeeded                     runner=GR1348941RLoRqn-L
Runner registered successfully. Feel free to start it, but if it's running already the config should be automatically reloaded!
 
Configuration (with the authentication token) was saved in "/etc/gitlab-runner/config.toml" 


$
```
Example output for bad token (I just deleted the runner and reset the token):
```
$ ./keyhacks.sh gitlab_runner_registration_token GR1348941RLoRqn-LN-ZsZHUoa23A
docker run --rm gitlab/gitlab-runner register --non-interactive --executor "docker" --docker-image alpine:latest --url "https://gitlab.com/" --registration-token "GR1348941RLoRqn-LN-ZsZHUoa23A" --description "keyhacks-test" --maintenance-note "Testing token with keyhacks" --tag-list "docker,aws" --run-untagged="true" --locked="false" --access-level="not_protected"

Runtime platform                                    arch=amd64 os=linux pid=7 revision=32fc1585 version=15.2.1
Running in system-mode.                            
                                                   
ERROR: Registering runner... forbidden (check registration token)  runner=GR1348941RLoRqn-L
PANIC: Failed to register the runner.              


$
```